### PR TITLE
Fix the build system so it can compile again

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,66 +1,111 @@
 buildscript {
-    repositories {
-        maven {
-            name = "mavenCentral"
-            url = "https://repo1.maven.org/maven2/"
-        }
-        maven {
-            name = "forge"
-            url = "http://files.minecraftforge.net/maven"
-        }
-        maven {
-            name = "sonatype"
-            url = "https://oss.sonatype.org/content/repositories/snapshots/"
-        }
-    }
-    dependencies {
-        classpath 'net.minecraftforge.gradle:ForgeGradle:1.2-SNAPSHOT'
-    }
+	repositories {
+		mavenCentral()
+		maven {
+			name = "gt"
+			url = "https://gregtech.overminddl1.com/"
+		}
+	}
+	dependencies {
+		classpath 'net.minecraftforge.gradle:ForgeGradle:1.2-SNAPSHOT'
+	}
 }
 
 repositories {
-    maven {
-        name 'CB Maven FS'
-        url "http://chickenbones.net/maven/"
-    }
-    maven {
-        url "https://maven.mcmoddev.com/"
-    }
+	maven {
+		name 'gt'
+		url "https://gregtech.overminddl1.com/"
+	}
 }
 
 apply plugin: 'forge'
 
-version = "@VERSION@"
+// Bump this every new code update after a version release, even if not releasing yet, that
+// way SNAPSHOT's work properly as something like `2.1.2-SNAPSHOT` orders before `2.1.2 in
+// SEMVER that gradle uses.
+version = "2.1.2"
 group = "ganymedes01.etfuturum"
 archivesBaseName = "Et_Futurum_Requiem"
 
 dependencies {
-    compile "codechicken:CodeChickenLib:1.7.10-1.1.3.140:dev"
-    compile "codechicken:CodeChickenCore:1.7.10-1.0.7.47:dev"
-    compile "codechicken:NotEnoughItems:1.7.10-1.0.5.120:dev"
-    compile "com.azanor:Thaumcraft:1.7.10-4.2.3.5:deobf"
-    compile "com.azanor:Baubles:1.7.10-1.0.1.10"
+	// Can use `compileOnly` instead of `compile` if you want to require it at build time,
+	// but not require it in `runClient`/`runServer`
+	compile "codechicken:CodeChickenLib:1.7.10-1.1.3.140:dev"
+	compile "codechicken:CodeChickenCore:1.7.10-1.0.7.47:dev"
+	compile "codechicken:NotEnoughItems:1.7.10-1.0.5.120:dev"
+	compile "com.azanor.baubles:Baubles:1.7.10-1.0.1.10:deobf"
+	compile "thaumcraft:Thaumcraft:1.7.10-4.2.3.5:dev"
 }
 
 minecraft {
-    version = "1.7.10-10.13.4.1614-1.7.10"
-    runDir = "eclipse/assets"
+	version = "1.7.10-10.13.4.1614-1.7.10"
+	runDir = "eclipse/assets"
 	replaceIn 'reference.java'
 	replace "@VERSION@", project.version
 }
 
 processResources {
-     from(sourceSets.main.resources.srcDirs) {
-          include 'mcmod.info'
-          expand 'version': project.version, 'mcversion': project.minecraft.version
-     }
+	from(sourceSets.main.resources.srcDirs) {
+		include 'mcmod.info'
+		expand 'version': project.version, 'mcversion': project.minecraft.version
+	 }
 
-     from(sourceSets.main.resources.srcDirs) {
-          exclude 'mcmod.info'
-     }
+	from(sourceSets.main.resources.srcDirs) {
+		exclude 'mcmod.info'
+	}
+}
+
 jar {
-    manifest {
-        attributes.put("AccessTransformer", "etfuturum_at.cfg")
-    }
+	manifest {
+		attributes(
+			'FMLAT': "etfuturum_at.cfg",
+		)
+	}
 }
+
+task sourceJar(type: Jar) {
+	manifest {}
+	classifier = 'sources'
+	from sourceSets.main.allSource
+	exclude 'assets/**'
 }
+
+task devJar(type: Jar) {
+	manifest {
+		attributes(
+			'FMLAT': 'etfuturum_at.cfg',
+		)
+	}
+	classifier = 'dev'
+	from sourceSets.main.output
+}
+
+artifacts {
+	archives sourceJar, devJar
+}
+
+
+if (!hasProperty("mavenUsername")) {
+	ext.mavenUsername="${System.getenv().MAVEN_USERNAME}"
+}
+
+if (!hasProperty("mavenPassword")) {
+	ext.mavenPassword="${System.getenv().MAVEN_PASSWORD}"
+}
+
+if (!hasProperty("mavenURL")) {
+	ext.mavenURL="${System.getenv().MAVEN_URL}"
+}
+
+
+uploadArchives {
+	repositories {
+		mavenDeployer {
+			uniqueVersion = false
+			repository(url: mavenURL) {
+				authentication(userName: mavenUsername, password: mavenPassword)
+			}
+		}
+	}
+}
+


### PR DESCRIPTION
Forge's maven broke more recently, made it incapable of compiling from a fresh build, this fixes that by switching to Gregtech's maven that has a fixed ForgeGradle.

Also adds a standard sources jar and a dev jar (which makes GT6 linking to this mod to add compatibility a bit easier as well as any other mod that may want to).

Also wow 89 meg builds, music.  ^.^

Deployed the 2.1.2 release to the GT6 maven as well for mods to link to for development, see the GT6 build.gradle file for the dependency descriptor if you want an example (it's commented by default).  If you want to be able to deploy to it yourself using a CI or manually or so to the maven then just ask for a username/password/token, or ping me when a new release is out and I can deploy it myself using my account again.